### PR TITLE
Fix: 传递 Platform ID 给 Platform Meta

### DIFF
--- a/kook_adapter/kook_adapter.py
+++ b/kook_adapter/kook_adapter.py
@@ -27,8 +27,9 @@ class KookPlatformAdapter(Platform):
 
     def meta(self) -> PlatformMetadata:
         return PlatformMetadata(
-            "kook",
-            "KOOK 适配器",
+            name="kook",
+            description="KOOK 适配器",
+            id=self.config.get("id")
         )
 
     async def run(self):


### PR DESCRIPTION
传递 Platform ID 给 PlatformMeta 以让 AstrMessageEvent 了解到平台适配器 ID