### PR TITLE
docs: 更新README.md,kook适配器已经并入Astrbto主线中,当前仓库即可存档

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# 此项目已经合并进Astrbot官方仓库中,[详见Astrbot PR #5658](https://github.com/AstrBotDevs/AstrBot/pull/5658),此仓库不在维护
+
+
 # 🎮 Kook 适配器：为 AstrBot 开启 Kook 交互新体验  
 
 


### PR DESCRIPTION
此项目已经合并进Astrbot官方仓库中,[详见Astrbot PR #5658](https://github.com/AstrBotDevs/AstrBot/pull/5658),此仓库不在维护